### PR TITLE
unicorn + systemcdのreload時の挙動確認

### DIFF
--- a/site-cookbooks/unicorn/templates/default/unicorn.service.erb
+++ b/site-cookbooks/unicorn/templates/default/unicorn.service.erb
@@ -8,6 +8,7 @@ WorkingDirectory=/var/www/<%= @app_name %>/current
 PIDFile=/var/www/stretcher_app/current/tmp/pids/unicorn.pid
 ExecStart=/usr/local/bin/bundle exec unicorn -c config/unicorn/<%= @rails_env %>.rb -E <%= @rails_env %>
 ExecReload=/bin/kill -USR2 $MAINPID
+KillSignal=SIGINT
 
 [Install]
 WantedBy=multi-user.target

--- a/site-cookbooks/unicorn/templates/default/unicorn.service.erb
+++ b/site-cookbooks/unicorn/templates/default/unicorn.service.erb
@@ -5,7 +5,7 @@ Description=unicorn
 User=app
 Group=app
 WorkingDirectory=/var/www/<%= @app_name %>/current
-ExecStart=/usr/local/bin/bundle exec unicorn -c config/unicorn/<%= @rails_env %>.rb -E deployment
+ExecStart=/usr/local/bin/bundle exec unicorn -c config/unicorn/<%= @rails_env %>.rb -E <%= @rails_env %>
 ExecReload=/bin/kill -USR2 $MAINPID
 
 [Install]

--- a/site-cookbooks/unicorn/templates/default/unicorn.service.erb
+++ b/site-cookbooks/unicorn/templates/default/unicorn.service.erb
@@ -5,7 +5,7 @@ Description=unicorn
 User=app
 Group=app
 WorkingDirectory=/var/www/<%= @app_name %>/current
-ExecStart=/usr/local/bin/bundle exec unicorn -c config/unicorn/<%= @rails_env %>.rb -E <%= @rails_env %>
+ExecStart=/usr/local/bin/bundle exec unicorn -c config/unicorn/<%= @rails_env %>.rb -E deployment
 ExecReload=/bin/kill -USR2 $MAINPID
 
 [Install]

--- a/site-cookbooks/unicorn/templates/default/unicorn.service.erb
+++ b/site-cookbooks/unicorn/templates/default/unicorn.service.erb
@@ -5,6 +5,7 @@ Description=unicorn
 User=app
 Group=app
 WorkingDirectory=/var/www/<%= @app_name %>/current
+PIDFile=/var/www/stretcher_app/current/tmp/pids/unicorn.pid
 ExecStart=/usr/local/bin/bundle exec unicorn -c config/unicorn/<%= @rails_env %>.rb -E <%= @rails_env %>
 ExecReload=/bin/kill -USR2 $MAINPID
 

--- a/site-cookbooks/unicorn/templates/default/unicorn.service.erb
+++ b/site-cookbooks/unicorn/templates/default/unicorn.service.erb
@@ -5,11 +5,9 @@ Description=unicorn
 User=app
 Group=app
 WorkingDirectory=/var/www/<%= @app_name %>/current
-PIDFile=/var/www/<%= @app_name %>/current/tmp/pids/unicorn.pids
 ExecStart=/usr/local/bin/bundle exec unicorn -c config/unicorn/<%= @rails_env %>.rb -E <%= @rails_env %>
 ExecReload=/bin/kill -USR2 $MAINPID
 ExecStop=/bin/kill -QUIT $MAINPID
-KillSignal=SIGINT
 
 [Install]
 WantedBy=multi-user.target

--- a/site-cookbooks/unicorn/templates/default/unicorn.service.erb
+++ b/site-cookbooks/unicorn/templates/default/unicorn.service.erb
@@ -7,7 +7,6 @@ Group=app
 WorkingDirectory=/var/www/<%= @app_name %>/current
 ExecStart=/usr/local/bin/bundle exec unicorn -c config/unicorn/<%= @rails_env %>.rb -E <%= @rails_env %>
 ExecReload=/bin/kill -USR2 $MAINPID
-ExecStop=/bin/kill -QUIT $MAINPID
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
reload時に新しいプロセスが立ち上がった後にすべてが消える事象が起きている。`bundle exec unicorn`のように直接叩くと新しいプロセスが残った状態になるので、systemdの何が悪いか探る

公式のサンプルはこちら
http://unicorn.bogomips.org/examples/unicorn%40.service
